### PR TITLE
Fix datastore_manipulations unit test

### DIFF
--- a/assembly/massa/datastore_manipulations/main.ts
+++ b/assembly/massa/datastore_manipulations/main.ts
@@ -30,7 +30,7 @@ export function main(_args: string): void {
     let msg2 = `keys2: ${keys2}`;
     // print(msg2);
     generateEvent(msg2);
-    assert(keys2.length == 2);
+    assert(keys2.length == 1);
 
     // Test using key prefixes
     const key3: StaticArray<u8> = [2, 0, 254, 255];


### PR DESCRIPTION
Erratum from PR #32 

Some last minute changes were breaking changes, and I didn't took the time to re-validate everything worked.
This will solve the issue