### PR TITLE
Fix abort message for use_builtins unit test

### DIFF
--- a/assembly/massa/use_builtins/main.ts
+++ b/assembly/massa/use_builtins/main.ts
@@ -2,5 +2,5 @@
 export function main(): void {
     seed();
     Date.now();
-    abort("abord with date and rnd", "use_builtins.ts");
+    abort("Manual abort with date and rnd", "use_builtins.ts");
 }


### PR DESCRIPTION
Fix the abort message on `use_builtins` test so it can be checked by `massa-sc-runtime`.
This issue makes https://github.com/massalabs/massa-sc-runtime/pull/253 fail